### PR TITLE
Add -critical-only flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A proxy of Mackerel alert webhook to [Grafana OnCall](https://grafana.com/produc
 Usage of ./mackerel-to-grafana-oncall:
   -allow-oncall-url-param
         allow Grafana oncall by url param
+  -critical-only
+        send critical only (ignore warning and unknown)
   -debug
         debug mode
   -grafana-oncall-url string
@@ -20,7 +22,7 @@ Usage of ./mackerel-to-grafana-oncall:
         show version
 ```
 
-Environment variables also can set these flags. `GRAFANA_ONCALL_URL`, `ALLOW_ON_CALL_URL_PARAM`, `PORT` and`DEBUG`.
+Environment variables also can set these flags. `GRAFANA_ONCALL_URL`, `ALLOW_ON_CALL_URL_PARAM`, `PORT` and etc.
 
 This server endpoint works as Mackerel alerting Webhook URL.
 

--- a/http_test.go
+++ b/http_test.go
@@ -14,7 +14,55 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+var testCases = []struct {
+	input  oncall.MackerelWebhook
+	status int
+	want   oncall.GrafanaOnCallFormattedWebhook
+}{
+	{
+		input: oncall.MackerelWebhook{
+			Orgname:  "test org",
+			Event:    "alert",
+			Memo:     "test memo",
+			ImageURL: "https://example.com/alerts/1234.png",
+			Alert: oncall.MackerelAlert{
+				ID:          "1234",
+				Status:      "critical",
+				URL:         "https://example.com/alerts/1234",
+				Monitorname: "test monitor",
+				Isopen:      true,
+			},
+		},
+		status: http.StatusOK,
+		want: oncall.GrafanaOnCallFormattedWebhook{
+			AlertUID:              "1234",
+			Title:                 "[test org] test monitor is critical",
+			ImageURL:              "https://example.com/alerts/1234.png",
+			LinkToUpstreamDetails: "https://example.com/alerts/1234",
+			State:                 "alerting",
+			Message:               "test memo",
+		},
+	},
+	{
+		input: oncall.MackerelWebhook{
+			Orgname:  "test org",
+			Event:    "alert",
+			Memo:     "test memo",
+			ImageURL: "https://example.com/alerts/1234.png",
+			Alert: oncall.MackerelAlert{
+				ID:          "9999",
+				Status:      "unknown",
+				URL:         "https://example.com/alerts/1234",
+				Monitorname: "test monitor",
+				Isopen:      true,
+			},
+		},
+		status: http.StatusNoContent,
+	},
+}
+
 func TestHTTPServer(t *testing.T) {
+	oncall.CriticalOnly = true
 	ch := make(chan oncall.GrafanaOnCallFormattedWebhook, 1)
 	grafanaServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hook := oncall.GrafanaOnCallFormattedWebhook{}
@@ -37,48 +85,36 @@ func TestHTTPServer(t *testing.T) {
 	defer proxyServer.Close()
 
 	// test
-	payload := oncall.MackerelWebhook{
-		Orgname:  "test org",
-		Event:    "alert",
-		Memo:     "test memo",
-		ImageURL: "https://example.com/alerts/1234.png",
-		Alert: oncall.MackerelAlert{
-			ID:          "1234",
-			Status:      "critical",
-			URL:         "https://example.com/alerts/1234",
-			Monitorname: "test monitor",
-			Isopen:      true,
-		},
-	}
-	b, _ := json.Marshal(payload)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, "POST", proxyServer.URL, bytes.NewReader(b))
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Errorf("failed to post: %s", err)
-		return
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("unexpected status code: %d (expected %d", resp.StatusCode, http.StatusOK)
-	}
+	for _, tc := range testCases {
+		payload := tc.input
+		t.Run(payload.IncidentTitle(), func(t *testing.T) {
+			b, _ := json.Marshal(payload)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			req, _ := http.NewRequestWithContext(ctx, "POST", proxyServer.URL, bytes.NewReader(b))
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("failed to post: %s", err)
+				return
+			}
+			if resp.StatusCode != tc.status {
+				t.Errorf("unexpected status code: %d (expected %d", resp.StatusCode, tc.status)
+			}
+			if tc.status != http.StatusOK {
+				return
+			}
 
-	// check
-	timeout := time.After(3 * time.Second)
-	select {
-	case <-timeout:
-		t.Errorf("timeout")
-	case grafanaRecieved := <-ch:
-		expected := oncall.GrafanaOnCallFormattedWebhook{
-			AlertUID:              "1234",
-			Title:                 "[test org] test monitor is critical",
-			ImageURL:              "https://example.com/alerts/1234.png",
-			LinkToUpstreamDetails: "https://example.com/alerts/1234",
-			State:                 "alerting",
-			Message:               "test memo",
-		}
-		if d := cmp.Diff(expected, grafanaRecieved); d != "" {
-			t.Errorf("unexpected GrafanaOnCallFormattedWebhook: %s", d)
-		}
+			// check
+			timeout := time.After(3 * time.Second)
+			select {
+			case <-timeout:
+				t.Errorf("timeout")
+			case grafanaRecieved := <-ch:
+				expected := tc.want
+				if d := cmp.Diff(expected, grafanaRecieved); d != "" {
+					t.Errorf("unexpected GrafanaOnCallFormattedWebhook: %s", d)
+				}
+			}
+		})
 	}
 }

--- a/mackerel.go
+++ b/mackerel.go
@@ -1,6 +1,9 @@
 package oncall
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type MackerelWebhook struct {
 	Orgname  string        `json:"orgName"`
@@ -33,6 +36,14 @@ func (h MackerelWebhook) IsTestPayload() bool {
 
 func (h MackerelWebhook) IsAlertEvent() bool {
 	return h.Event == "alert"
+}
+
+func (h MackerelWebhook) IsCritical() bool {
+	return strings.ToLower(h.Alert.Status) == "critical"
+}
+
+func (h MackerelWebhook) ID() string {
+	return h.Alert.ID
 }
 
 func (h MackerelWebhook) IncidentTitle() string {


### PR DESCRIPTION
When `-critical-only` is specified, Mackerel alerts status `warning` and `unknown` are ignored.