### PR TITLE
fix --critical-only ignored ok events.

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -59,6 +59,30 @@ var testCases = []struct {
 		},
 		status: http.StatusNoContent,
 	},
+	{
+		input: oncall.MackerelWebhook{
+			Orgname:  "test org",
+			Event:    "alert",
+			Memo:     "test memo",
+			ImageURL: "https://example.com/alerts/1234.png",
+			Alert: oncall.MackerelAlert{
+				ID:          "1234",
+				Status:      "ok",
+				URL:         "https://example.com/alerts/1234",
+				Monitorname: "test monitor",
+				Isopen:      false,
+			},
+		},
+		status: http.StatusOK,
+		want: oncall.GrafanaOnCallFormattedWebhook{
+			AlertUID:              "1234",
+			Title:                 "[test org] test monitor is ok",
+			ImageURL:              "https://example.com/alerts/1234.png",
+			LinkToUpstreamDetails: "https://example.com/alerts/1234",
+			State:                 "ok",
+			Message:               "test memo",
+		},
+	},
 }
 
 func TestHTTPServer(t *testing.T) {

--- a/mackerel.go
+++ b/mackerel.go
@@ -38,8 +38,9 @@ func (h MackerelWebhook) IsAlertEvent() bool {
 	return h.Event == "alert"
 }
 
-func (h MackerelWebhook) IsCritical() bool {
-	return strings.ToLower(h.Alert.Status) == "critical"
+func (h MackerelWebhook) IsCriticalOrOK() bool {
+	s := strings.ToLower(h.Alert.Status)
+	return s == "critical" || s == "ok"
 }
 
 func (h MackerelWebhook) ID() string {

--- a/oncall.go
+++ b/oncall.go
@@ -136,7 +136,7 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 		grafanaHook = GrafanaOnCallFormattedWebhookTestPayload
 	} else if hook.IsAlertEvent() {
 		grafanaHook = hook.ToGrafanaOnCallFormattedWebhook()
-		if CriticalOnly && !hook.IsCritical() {
+		if CriticalOnly && !hook.IsCriticalOrOK() {
 			sendResponse(w, http.StatusNoContent, fmt.Errorf("not a critical event. ignored. ID:%s Event:%s", hook.ID(), hook.Event))
 			return
 		}


### PR DESCRIPTION
When a critical alert recovered, ok events will be sent.